### PR TITLE
Issue 24 - User-specified template function

### DIFF
--- a/R/register_fpca.R
+++ b/R/register_fpca.R
@@ -12,10 +12,19 @@
 #' Requires input data \code{Y} to be a dataframe in long format with variables 
 #' \code{id}, \code{index}, and \code{value} to indicate subject IDs, times, and observations, 
 #' respectively.
+#' 
+#' The joint iterations start with a registration step.
+#' The template function for this registration step is defined by argument
+#' \code{Y_template}.
 #'
 #' @param family One of \code{c("gaussian","binomial","gamma")}.
 #' For \code{"gamma"}, the \code{fpca_type} is fixed to \code{"two-step"}.
 #' Defaults to \code{"gaussian"}.
+#' @param Y_template Optional dataframe with the same structure as \code{Y}.
+#' Only used for the initial registration step. If NULL,
+#' curves are registered to the overall mean of all curves in \code{Y} as template function.
+#' If specified, the template function is taken as the mean
+#' of all curves in \code{Y_template}. Defaults to NULL.
 #' @param max_iterations Number of iterations for overall algorithm. Defaults to 10.
 #' @param npc Number of principal components to calculate. Defaults to 1. 
 #' @param fpca_type One of \code{c("variationalEM","two-step")}.
@@ -109,6 +118,7 @@
 #'
 register_fpca = function(Y, Kt = 8, Kh = 4, family = "binomial",
 												 preserve_domain = TRUE, lambda_endpoint = NULL,
+												 Y_template = NULL,
 												 max_iterations = 10, npc = 1,
 												 fpca_type = "variationalEM", fpca_maxiter = 50,
 												 fpca_seed = 1988, fpca_error_thresh = 0.0001,
@@ -135,6 +145,7 @@ register_fpca = function(Y, Kt = 8, Kh = 4, family = "binomial",
   registr_step = registr(Y = Y, Kt = Kt, Kh = Kh, family = family,
   											 preserve_domain = preserve_domain,
   											 lambda_endpoint = lambda_endpoint,
+  											 Y_template      = Y_template,
   											 row_obj = rows, cores = cores, ...)
   time_warps[[2]] = registr_step$Y$index
   loss[1] = registr_step$loss

--- a/R/registr.R
+++ b/R/registr.R
@@ -194,7 +194,7 @@ registr = function(obj = NULL, Y = NULL, Kt = 8, Kh = 4, family = "binomial", gr
 			if (!all(c("id", "index", "value") %in% names(Y_template))) {
 				stop("Y_template must have variables 'id', 'index', and 'value'.")
 			} else if (!identical(range(Y_template$index), range(Y$index))) {
-				stop("range(Y_template$index) must be equal to range(Y$index).")
+				stop("The range of 'index' must be equal for Y_template and Y.")
 			}
 			Y_template$tstar = Y_template$index
 			mean_dat         = Y_template

--- a/man/register_fpca.Rd
+++ b/man/register_fpca.Rd
@@ -11,6 +11,7 @@ register_fpca(
   family = "binomial",
   preserve_domain = TRUE,
   lambda_endpoint = NULL,
+  Y_template = NULL,
   max_iterations = 10,
   npc = 1,
   fpca_type = "variationalEM",
@@ -42,6 +43,12 @@ Defaults to \code{TRUE}. Can only be set to \code{FALSE} when
 deviation of the warping function endpoints from the diagonal. The higher
 this lambda, the more the endpoints are forced towards the diagonal.
 Only used if \code{preserve_domain = FALSE}.}
+
+\item{Y_template}{Optional dataframe with the same structure as \code{Y}.
+Only used for the initial registration step. If NULL,
+curves are registered to the overall mean of all curves in \code{Y} as template function.
+If specified, the template function is taken as the mean
+of all curves in \code{Y_template}. Defaults to NULL.}
 
 \item{max_iterations}{Number of iterations for overall algorithm. Defaults to 10.}
 
@@ -104,6 +111,10 @@ By specifying \code{cores > 1} the registration call can be parallelized.
 Requires input data \code{Y} to be a dataframe in long format with variables 
 \code{id}, \code{index}, and \code{value} to indicate subject IDs, times, and observations, 
 respectively.
+
+The joint iterations start with a registration step.
+The template function for this registration step is defined by argument
+\code{Y_template}.
 }
 \examples{
 library(ggplot2)

--- a/man/registr.Rd
+++ b/man/registr.Rd
@@ -14,6 +14,7 @@ registr(
   gradient = TRUE,
   preserve_domain = TRUE,
   lambda_endpoint = NULL,
+  Y_template = NULL,
   beta = NULL,
   t_min = NULL,
   t_max = NULL,
@@ -51,6 +52,12 @@ Defaults to \code{TRUE}. Can only be set to \code{FALSE} when
 deviation of the warping function endpoints from the diagonal. The higher
 this lambda, the more the endpoints are forced towards the diagonal.
 Only used if \code{preserve_domain = FALSE}.}
+
+\item{Y_template}{Optional dataframe with the same structure as \code{Y}.
+Only used if \code{obj} is NULL. If \code{Y_template} is NULL,
+curves are registered to the overall mean of all curves in \code{Y} as template function.
+If \code{Y_template} is specified, the template function is taken as the mean
+of all curves in \code{Y_template}. Default is NULL.}
 
 \item{beta}{Current estimates for beta for each subject. Default is NULL.}
 
@@ -104,6 +111,10 @@ domain-preserving. This behavior can be changed by setting
 For further details see the accompanying vignette. \cr \cr
 By specifying \code{cores > 1} the registration call can be parallelized.
 }
+\details{
+The template function for the registration is defined by argument \code{obj}
+or \code{Y_template}, depending on if \code{obj} is NULL or not, respectively.
+}
 \examples{
 ### complete binomial curves
 Y = simulate_unregistered_curves()
@@ -131,6 +142,14 @@ ggplot(register_step2b$Y, aes(x = tstar, y = index, group = id)) +
   geom_line(alpha = 0.2) +
   ggtitle("Estimated warping functions")
 }
+
+# Define the template function only over a subset of the curves
+template_ids    = c("boy01","boy29","boy30","boy31","boy34","boy36")
+Y_template      = growth_incomplete[growth_incomplete$id \%in\% template_ids,]
+register_step2c = registr(obj = NULL, Y = growth_incomplete, Kt = 6, Kh = 4,
+                          family = "gaussian", gradient = TRUE,
+                          Y_template = Y_template,
+                          preserve_domain = FALSE, lambda_endpoint = 1)
 
 }
 \author{

--- a/tests/testthat/test-register_fpca.R
+++ b/tests/testthat/test-register_fpca.R
@@ -186,3 +186,23 @@ test_that("register_fpca for gamma data throws no error",{
 	}, "Convergence not reached. Try increasing max_iterations.")
 	expect_identical(class(reg), "registration")
 })
+
+test_that("register_fpca only accepts Y_template if it has the correct format.",{
+	Y = registr::growth_incomplete
+	
+	template_ids1 = "girl18"
+	Y_template1   = Y[Y$id %in% template_ids1,]
+	template_ids2 = "boy30"
+	Y_template2   = Y[Y$id %in% template_ids2,]
+	template_ids3 = c("boy01","boy29","boy30","boy31","boy34","boy36")
+	Y_template3   = Y[Y$id %in% template_ids3,]
+	
+	expect_error(register_fpca(Y = Y, family = "gaussian", Y_template = Y_template1$value),
+							 "Y_template must have variables 'id', 'index', and 'value'.")
+	expect_error(register_fpca(Y = Y, family = "gaussian", Y_template = Y_template1),
+							 "The range of 'index' must be equal for Y_template and Y.")
+	expect_error(register_fpca(Y = Y, family = "gaussian", Y_template = Y_template2, max_iterations = 2),
+							 NA)
+	expect_error(register_fpca(Y = Y, family = "gaussian", Y_template = Y_template3, max_iterations = 2),
+							 NA)
+})

--- a/tests/testthat/test-registr.R
+++ b/tests/testthat/test-registr.R
@@ -109,3 +109,23 @@ test_that("registr function throws an error when family = 'gamma' is applied to 
 	expect_error(registr(Y = Y, family = "gamma"),
 							 "family = 'gamma' can only be applied to strictly positive data.")
 })
+
+test_that("registr function only accepts Y_template if it has the correct format.",{
+	Y = registr::growth_incomplete
+	
+	template_ids1 = "girl18"
+	Y_template1   = Y[Y$id %in% template_ids1,]
+	template_ids2 = "boy30"
+	Y_template2   = Y[Y$id %in% template_ids2,]
+	template_ids3 = c("boy01","boy29","boy30","boy31","boy34","boy36")
+	Y_template3   = Y[Y$id %in% template_ids3,]
+	
+	expect_error(registr(Y = Y, family = "gaussian", Y_template = Y_template1$value),
+							 "Y_template must have variables 'id', 'index', and 'value'.")
+	expect_error(registr(Y = Y, family = "gaussian", Y_template = Y_template1),
+							 "The range of 'index' must be equal for Y_template and Y.")
+	expect_error(registr(Y = Y, family = "gaussian", Y_template = Y_template2),
+							 NA)
+	expect_error(registr(Y = Y, family = "gaussian", Y_template = Y_template3),
+							 NA)
+})


### PR DESCRIPTION
This PR contains the functionality to resolve #24.
The new argument `Y_template` is now implemented for `register_fpca()` (used in the initial registration step only) and `registr()`. Unit tests are included for both functions. Regarding the examples in the help pages, I only included one for the `registr()` function since it's sort of a subordinate functionality.

@julia-wrobel Okay for you, or do you have some more thoughts on the problem of user-specified template functions in the first place?